### PR TITLE
fixing a possible bug in cached random walks

### DIFF
--- a/runLinkPrediction_ppi.py
+++ b/runLinkPrediction_ppi.py
@@ -217,10 +217,10 @@ def main(args):
     else:
         # generate pos_train_g and simulate walks
         pos_train_g = N2vGraph(pos_train_graph, args.p, args.q)
-    start = time.time()
-    pos_train_g.simulate_walks(args.num_walks, args.walk_length, args.use_cached_random_walks)
-    end = time.time()
-    logging.info("simulating walks: {} seconds".format(end - start))
+        start = time.time()
+        pos_train_g.simulate_walks(args.num_walks, args.walk_length, args.use_cached_random_walks)
+        end = time.time()
+        logging.info("simulating walks: {} seconds".format(end - start))
 
     if args.cache_random_walks and args.random_walks:
         logging.info(f"Caching random walks to {args.random_walks}")


### PR DESCRIPTION
@deepakunni3 Hi Deepak, I think there was a small bug in runLinkPrediction_ppi.py code. Could you please verify if it corrects now? Thanks.
Starting from line 217 in runLinkPrediction_ppi
 `else:`
       `# generate pos_train_g and simulate walks` 
       ` pos_train_g = N2vGraph(pos_train_graph, args.p, args.q)`
        `start= time.time()` 
        `pos_train_g.simulate_walks(args.num_walks, args.walk_length, args.use_cached_random_walks)` 
       `end = time.time()` 
        `logging.info("simulating walks: {} seconds".format(end - start))` 

This line `pos_train_g.simulate_walks(args.num_walks, args.walk_length, args.use_cached_random_walks)` was out of else.