### PR TITLE
Add packaging to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "ensmallen_graph>=0.6.0",
         "cache_decorator>=2.0.2",
         "validate_version_code"
+        "packaging"
     ],
     tests_require=test_deps,
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "extra_keras_metrics>=2.0.1",
         "ensmallen_graph>=0.6.0",
         "cache_decorator>=2.0.2",
-        "validate_version_code"
+        "validate_version_code",
         "packaging"
     ],
     tests_require=test_deps,


### PR DESCRIPTION
"tensorflow_utils.py" imports version from packaging, raising ModuleNotFoundError if it isn't available.