### PR TITLE
fixed deprecated matplotlib legendHandles

### DIFF
--- a/embiggen/visualizations/graph_visualizer.py
+++ b/embiggen/visualizations/graph_visualizer.py
@@ -774,7 +774,7 @@ class GraphVisualizer:
 
         # Setting maximum alpha to the visualization
         # to avoid transparency in the dots.
-        for legend_handle in legend.legendHandles:
+        for legend_handle in legend.legend_handles:
             legend_handle.set_alpha(1)
             try:
                 legend_handle._legmarker.set_alpha(1)

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         "Jinja2",
         "tqdm",
         "humanize",
-        "matplotlib>=3.5.2",
+        "matplotlib>=3.9",
         "scikit-learn>=1.2",
         "dict_hash>=1.1.32",
         "userinput>=1.0.20",


### PR DESCRIPTION
`embiggen.visualizations` uses a undocumented/deprecated feature of matplotlib (`legend.legendHandles`) which fails whenever plotting anything with a legend in Embiggen.

Here's the related deprecation/removal notice in matplotlib=3.9 for reference
https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.9.0.html#miscellaneous-removals


